### PR TITLE
Fix: allow negative total votes for annotations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "genius-rust"
 description = "Rust library that allows interact with Genius API"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Pedro Mendes <pedromendescraft@gmail.com>", "Tsiry Sandratraina <tsirysndr@aol.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -46,7 +46,7 @@ pub struct Annotation {
     pub url: String,
     pub verified: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub votes_total: Option<u32>,
+    pub votes_total: Option<i32>,
     pub current_user_metadata: UserMetadata,
     pub authors: Vec<AnnotationAuthor>,
 }


### PR DESCRIPTION
Song annotations can have negative total votes (see htps://api.genius.com/songs/6932699 as an example), which breaks the deserialization process. 